### PR TITLE
Task#94762

### DIFF
--- a/connector_prestashop/components/exporter.py
+++ b/connector_prestashop/components/exporter.py
@@ -75,11 +75,10 @@ class PrestashopBaseExporter(AbstractComponent):
         # cuando crea la combinación y utiliza el binder, no sé por qué
         # devuelve un diccionario, no un id de prestashop
         # entonces el binder.bind peta y no se guarda el prestashop_id
-        # lo parseamos y lo guardamos en vez de hacer el binder bind
+        # lo parseamos y se lo pasamos para hacer el binder bind
         presta_id = self.prestashop_id.get(
             'prestashop', {}).get(
             'combination', {}).get('id', 0)
-        # self.env.cr.commit()
         self.binder.bind(presta_id, self.binding)
         # commit so we keep the external ID if several cascading exports
         # are called and one of them fails

--- a/connector_prestashop/models/binding/common.py
+++ b/connector_prestashop/models/binding/common.py
@@ -70,6 +70,17 @@ class PrestashopBinding(models.AbstractModel):
     @job(default_channel='root.prestashop')
     @related_action(action='related_action_record')
     @api.multi
+    def export_record_saving_prestashop_id(self, fields=None):
+        """ Export a record on PrestaShop """
+        self.ensure_one()
+        self.check_active(self.backend_id)
+        with self.backend_id.work_on(self._name) as work:
+            exporter = work.component(usage='record.exporter')
+            return exporter.run_saving_prestashop_id(self, fields)
+
+    @job(default_channel='root.prestashop')
+    @related_action(action='related_action_record')
+    @api.multi
     def export_delete_record(self, backend, external_id, attributes=None):
         """ Delete a record on PrestaShop """
         self.check_active(backend)

--- a/connector_prestashop_catalog_manager/models/product_template/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_template/exporter.py
@@ -113,6 +113,8 @@ class ProductTemplateExporter(Component):
                         'odoo_id': product.id,
                         'main_template_id': self.binding_id,
                     })
+                # sólo lo exportamos si se ha creado uno nuevo y
+                # con la función nueva export_record_saving_prestashop_id
                 combination.with_delay(
                     priority=50,
                     eta=timedelta(seconds=20)

--- a/connector_prestashop_catalog_manager/models/product_template/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_template/exporter.py
@@ -102,21 +102,21 @@ class ProductTemplateExporter(Component):
         for product in self.binding.product_variant_ids:
             if not product.attribute_value_ids:
                 continue
-            combination_ext = combination_obj.search([
+            combination = combination_obj.search([
                 ('backend_id', '=', self.backend_record.id),
                 ('odoo_id', '=', product.id),
-            ])
-            if not combination_ext:
-                combination_ext = combination_obj.with_context(
+            ], limit=1)
+            if not combination:
+                combination = combination_obj.with_context(
                     connector_no_export=True).create({
                         'backend_id': self.backend_record.id,
                         'odoo_id': product.id,
                         'main_template_id': self.binding_id,
                     })
-            # If a template has been modified then always update PrestaShop
-            # combinations
-            combination_ext.with_delay(
-                priority=50, eta=timedelta(seconds=20)).export_record()
+                combination.with_delay(
+                    priority=50,
+                    eta=timedelta(seconds=20)
+                ).export_record_saving_prestashop_id()
 
     def _not_in_variant_images(self, image):
         images = []


### PR DESCRIPTION
arreglado error de duplicidad en las variantes cada vez que sincronizaba el template. Hacer que se guarde en odoo el id de prestashop una vez creada la variante en prestashop
