### PR TITLE
Task#105393

### DIFF
--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -145,7 +145,7 @@ class PrestashopProductTemplate(models.Model):
         self_loc = self.with_context(location=locations.ids,
                                      compute_child=False)
         for product in self_loc:
-            if self_loc.no_export:
+            if product.no_export:
                 continue
             new_qty = product._prestashop_qty(backend)
             if product.quantity != new_qty:

--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -145,6 +145,8 @@ class PrestashopProductTemplate(models.Model):
         self_loc = self.with_context(location=locations.ids,
                                      compute_child=False)
         for product in self_loc:
+            if self_loc.no_export:
+                continue
             new_qty = product._prestashop_qty(backend)
             if product.quantity != new_qty:
                 product.quantity = new_qty


### PR DESCRIPTION
En el product.template de prestashop existe un check para evitar que se actualice la cantidad disponible, pero siempre se actualiza independientemente de si está o no activado. Debuggeando el código he visto que no se hacía esa comprobación, así que la he añadido al mismo prestashop ya que es un error del módulo.
